### PR TITLE
.find by string id now works as expected

### DIFF
--- a/lib/acts_as_hashids/core.rb
+++ b/lib/acts_as_hashids/core.rb
@@ -13,7 +13,17 @@ module ActsAsHashids
       def find(ids = nil, &block)
         return detect(&block) if block.present? && respond_to?(:detect)
 
-        encoded_ids = Array(ids).map { |id| id.is_a?(String) ? id : hashids.encode(id) }.flatten
+        encoded_ids = Array(ids).map do |id|
+          begin
+            id = id.to_i if Float(id)
+            hashids.encode(id)
+          rescue TypeError, ArgumentError
+            id
+          end
+        end
+
+        encoded_ids = encoded_ids.flatten
+
         res = with_hashids(encoded_ids).all
         if ids.is_a?(Array)
           raise_record_not_found_exception! encoded_ids, res.size, encoded_ids.size if res.size != encoded_ids.size

--- a/spec/acts_as_hashids/core_spec.rb
+++ b/spec/acts_as_hashids/core_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe ActsAsHashids::Core do
           )
         end
       end
+      it 'returns the record when finding by string id' do
+        expect(subject.find(foo1.id.to_s)).to eq foo1
+      end
     end
     context 'for multiple arguments' do
       it 'decodes hash id and returns the record' do


### PR DESCRIPTION
Related to #3, if you do `Model.find('1')` it throws an `Decode error: ["xxx"]` exception and should be the same as `Model.find(1)`. This commit fix this issue.