### PR TITLE
Update Ruby version constraints to allow Ruby v2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,12 @@ before_install:
   - gem update --system
   - gem --version
 install:
-  - gem install bundler
+  # Bundler v2 only supports Ruby v2.3 and above
+  # For Ruby v2.2, install Bundler v1.x
+  - if [ $TRAVIS_RUBY_VERSION == "2.2" ];
+    then gem install bundler -v '< 2';
+    else gem install bundler;
+    fi
   - bundle --version
   - bundle install --jobs=3 --retry=3
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 env:
   -
   - ACTIVE_RECORD_VERSION=4.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.0.0
     - rvm: 2.5
       env: ACTIVE_RECORD_VERSION=4.1.0
+    - rvm: 2.6
+      env: ACTIVE_RECORD_VERSION=4.0.0
+    - rvm: 2.6
+      env: ACTIVE_RECORD_VERSION=4.1.0
 before_install:
   - gem update --system
   - gem --version

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '< 2.6']
+  spec.required_ruby_version = ['>= 2.2.2', '< 2.7']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 6.0'
   spec.add_runtime_dependency 'hashids', '~> 1.0'


### PR DESCRIPTION
Hi there,

Great gem! I just updated to Ruby v2.6, but acts_as_hashids is unhappy with my update. I pulled this repo and ran all tests locally with Ruby v2.6 and everything appears fine.

Thoughts? :grin: 