### PR TITLE
Support ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 env:
   jobs:
   -
@@ -25,6 +26,10 @@ matrix:
     - rvm: 2.6
       env: ACTIVE_RECORD_VERSION=4.0.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.6
+      env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
+    - rvm: 2.7
+      env: ACTIVE_RECORD_VERSION=4.0.0 SQLITE3_VERSION=1.3.13
+    - rvm: 2.7
       env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.0.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.7
       env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
+    - rvm: 2.7
+      env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.0.0
 before_install:

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '< 2.7']
+  spec.required_ruby_version = ['>= 2.2.2', '< 3.0']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 6.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'


### PR DESCRIPTION
We are upgrading our application to ruby 2.7 and this gem is one of the blockers. There seems to be no technical reason why this gem cannot support ruby 2.7, so this PR adds that support. I've bumped the ruby version in the gemspec and added the corresponding travis builds and exclusions. Note that ActiveSupport 4.x does not work with ruby 2.7 due to some issues with BigDecimal, so I have added this as an allowed failure.