### PR TITLE
Add support for ruby 3.0 & 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,9 @@ Documentation:
   Enabled: false
 Style/SignalException:
   EnforcedStyle: only_raise
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Metrics/PerceivedComplexity:
   Max: 10
 Metrics/BlockLength:
   Enabled: false
-Documentation:
+Style/Documentation:
   Enabled: false
 Style/SignalException:
   EnforcedStyle: only_raise

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Documentation:
   Enabled: false
 Style/SignalException:
   EnforcedStyle: only_raise
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,12 +7,6 @@ AllCops:
     - "vendor/**/*"
 Metrics/AbcSize:
   Max: 40
-Metrics/LineLength:
-  Max: 125
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
 Metrics/MethodLength:
   Max: 20
 Metrics/CyclomaticComplexity:
@@ -25,6 +19,12 @@ Documentation:
   Enabled: false
 Style/SignalException:
   EnforcedStyle: only_raise
+Layout/LineLength:
+  Max: 125
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstArrayElementIndentation:
@@ -32,6 +32,18 @@ Layout/FirstArrayElementIndentation:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 Lint/InheritException:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Style/SignalException:
   EnforcedStyle: only_raise
 Layout/IndentHash:
   EnforcedStyle: consistent
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.6
   - 2.7
   - 3.0
+  - 3.1
 env:
   jobs:
   -
@@ -44,9 +45,19 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
     - rvm: 3.0
       env: ACTIVE_RECORD_VERSION=5.0.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.1
+      env: ACTIVE_RECORD_VERSION=4.0.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.1
+      env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.1
+      env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.1
+      env: ACTIVE_RECORD_VERSION=5.0.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.0.0
     - rvm: 3.0
+      env: ACTIVE_RECORD_VERSION=6.0.0
+    - rvm: 3.1
       env: ACTIVE_RECORD_VERSION=6.0.0
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
   - ACTIVE_RECORD_VERSION=5.0.0 SQLITE3_VERSION=1.3.13
   - ACTIVE_RECORD_VERSION=6.0.0
+  - ACTIVE_RECORD_VERSION=6.1.0
+  - ACTIVE_RECORD_VERSION=7.0.0
 matrix:
   allow_failures:
     - rvm: 2.4
@@ -35,6 +37,14 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.0.0
+    - rvm: 2.4
+      env: ACTIVE_RECORD_VERSION=6.1.0
+    - rvm: 2.4
+      env: ACTIVE_RECORD_VERSION=7.0.0
+    - rvm: 2.5
+      env: ACTIVE_RECORD_VERSION=7.0.0
+    - rvm: 2.6
+      env: ACTIVE_RECORD_VERSION=7.0.0
 before_install:
   - gem update --system
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
     - rvm: 3.0
       env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.0
+      env: ACTIVE_RECORD_VERSION=5.0.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.0.0
     - rvm: 3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 env:
   jobs:
   -
@@ -35,7 +36,15 @@ matrix:
       env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.7
       env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.0
+      env: ACTIVE_RECORD_VERSION=4.0.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.0
+      env: ACTIVE_RECORD_VERSION=4.1.0 SQLITE3_VERSION=1.3.13
+    - rvm: 3.0
+      env: ACTIVE_RECORD_VERSION=4.2.0 SQLITE3_VERSION=1.3.13
     - rvm: 2.4
+      env: ACTIVE_RECORD_VERSION=6.0.0
+    - rvm: 3.0
       env: ACTIVE_RECORD_VERSION=6.0.0
     - rvm: 2.4
       env: ACTIVE_RECORD_VERSION=6.1.0

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.3.0', '<= 3.1.1']
+  spec.required_ruby_version = ['>= 2.3.0', '< 3.2']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.54.0'
+  spec.add_development_dependency 'rubocop', '~> 0.68.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.24.0'
   spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'sqlite3', '~> 1.3'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '< 3.1']
+  spec.required_ruby_version = ['>= 2.2.2', '<= 3.1.1']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['>= 2.2.2', '< 3.0']
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 6.1'
+  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'
 
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '< 3.0']
+  spec.required_ruby_version = ['>= 2.2.2', '< 3.1']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '<= 3.1.1']
+  spec.required_ruby_version = ['>= 2.3.0', '<= 3.1.1']
 
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
   spec.add_runtime_dependency 'hashids', '~> 1.0'
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.68.0'
+  spec.add_development_dependency 'rubocop', '~> 0.81.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.24.0'
   spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'sqlite3', '~> 1.3'

--- a/lib/acts_as_hashids/core.rb
+++ b/lib/acts_as_hashids/core.rb
@@ -59,7 +59,7 @@ module ActsAsHashids
         where(primary_key => decoded_ids)
       end
 
-      def has_many(*args, &block) # rubocop:disable Style/PredicateName
+      def has_many(*args, &block) # rubocop:disable Naming/PredicateName
         options = args.extract_options!
         options[:extend] = (options[:extend] || []).concat([FinderMethods])
         super(*args, **options, &block)

--- a/lib/acts_as_hashids/core.rb
+++ b/lib/acts_as_hashids/core.rb
@@ -62,7 +62,7 @@ module ActsAsHashids
       def has_many(*args, &block) # rubocop:disable Style/PredicateName
         options = args.extract_options!
         options[:extend] = (options[:extend] || []).concat([FinderMethods])
-        super(*args, options, &block)
+        super(*args, **options, &block)
       end
 
       def relation


### PR DESCRIPTION
## Summary

This adds support for Ruby 3.0 and 3.1. It builds off of [this pull request](https://github.com/dtaniwaki/acts_as_hashids/pull/18).

## Highlights

1. Fixes separation of positional arguments from keyword arguments in `ActsAsHashids::Core::ClassMethods#has_many`
2. Upgrades rubocop to `~> 0.81.0`. This was necessitated by two things. 
    -  Ruby 3.1 ships with psych 4.0 by default whose `#safe_load` method now accepts both positional and **keyword** arguments. This results in an `ArgumentError` when calling `Rubocop::ConfigLoader.yaml_safe_load`.
    -  Calling `Rubocop::ConfigLoaderResolver#merge` in `Rubocop::ConfigLoaderResolver#merge_with_default` results in an `ArgumentError` because `opts` should now be passed as a **keyword** argument.

4. Upgrades the least required ruby version to `2.3.0` since this is the least required Ruby version by `rubocop, '~> 0.81.0'`.

