### PR TITLE
Support Activerecord 7.1

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,8 +16,7 @@ jobs:
           bundler-cache: true
       - name: Install dependencies
         env:
-          ACTIVE_RECORD_VERSION: 7.0
+          ACTIVE_RECORD_VERSION: 7.1
         run: bundle install --jobs 3 --retry 3
       - name: Run tests
         run: bundle exec rubocop -D
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["2.7.5", "3.0.3", "3.1.0", "3.2.0"]
-        active_record_version: ["6.0", "6.1", "7.0"]
+        active_record_version: ["6.0", "6.1", "7.0", "7.1"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
@@ -42,4 +42,3 @@ jobs:
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true
-

--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ['>= 2.3.0', '< 3.3']
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.1'
+  spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 7.2'
   spec.add_runtime_dependency 'hashids', '~> 1.0'
 
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5'


### PR DESCRIPTION
This PR is to add support for Activerecord 7.1.

Changes:
- update runtime_dependency
- update ga ci

resolves #25 